### PR TITLE
#170785988 Delete an announcement

### DIFF
--- a/server/Controllers/announcementController.js
+++ b/server/Controllers/announcementController.js
@@ -1,12 +1,14 @@
 /* eslint-disable radix */
 import createAnnouncement from '../Helpers/createAnnouncement';
 import successResponse from '../Helpers/successResponse';
+import failureResponse from '../Helpers/failureResponse';
+import deleteResponse from '../Helpers/deleteResponse';
 import updateAnnouncement from '../Helpers/updateAnnouncement';
 import findAllAnnouncements from '../Helpers/findAllAnnouncements';
 import findAnnouncementByStatus from '../Helpers/findByStatus';
 import findById from '../Helpers/findById';
 import validStatus from '../Helpers/validateStatus';
-import failureResponse from '../Helpers/failureResponse';
+import deleteAnnouncement from '../Helpers/delete';
 
 class AnnouncementController {
   static create(req, res) {
@@ -42,6 +44,12 @@ class AnnouncementController {
     const id = parseInt(req.params.id);
     const announcement = findById(id);
     return successResponse(res, 200, 'success', announcement);
+  }
+
+  static delete(req, res) {
+    const id = parseInt(req.params.id);
+    deleteAnnouncement(id);
+    deleteResponse(res, 200, 'success');
   }
 }
 export default AnnouncementController;

--- a/server/Helpers/delete.js
+++ b/server/Helpers/delete.js
@@ -1,0 +1,9 @@
+import Announcement from '../Models/announcement';
+import findById from './findById';
+
+const deleteAnnouncement = (id) => {
+  const announcement = findById(id);
+  const announcementIndex = Announcement.indexOf(announcement);
+  return Announcement.splice(announcementIndex, 1);
+};
+export default deleteAnnouncement;

--- a/server/Helpers/deleteResponse.js
+++ b/server/Helpers/deleteResponse.js
@@ -1,0 +1,8 @@
+const successResponse = (response, status, message) => (
+  response.status(status)
+    .json({
+      status,
+      message,
+    })
+);
+export default successResponse;

--- a/server/Routes/announcementRoutes.js
+++ b/server/Routes/announcementRoutes.js
@@ -13,4 +13,5 @@ router.patch('/api/v1/announcement/:id', authentication, notFound, authorization
 router.get('/api/v1/announcement', authentication, announcementController.all);
 router.get('/api/v1/announcements', authentication, announcementController.findByStatus);
 router.get('/api/v1/announcement/:id', authentication, notFound, authorization, announcementController.getAnnouncement);
+router.delete('/api/v1/announcement/:id', authentication, notFound, authorization, announcementController.delete);
 export default router;

--- a/server/Tests/announcementsTest.test.js
+++ b/server/Tests/announcementsTest.test.js
@@ -178,9 +178,20 @@ describe('User tests', () => {
       });
   });
 
-  it('should an announcement', (done) => {
+  it('should get an announcement', (done) => {
     chai.request(server)
       .get(`/api/v1/announcement/${announcementID}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(200);
+        expect(res.body.message).to.equal('success');
+        done();
+      });
+  });
+
+  it('should delete an announcement', (done) => {
+    chai.request(server)
+      .delete(`/api/v1/announcement/${announcementID}`)
       .set('Authorization', `Bearer ${userToken}`)
       .end((error, res) => {
         res.body.status.should.be.equal(200);


### PR DESCRIPTION
#### What does this PR do?

- It allows the admin to delete announcements

#### Description of Task to be completed?

- The admin can delete announcements

#### How should this be manually tested?

- Use this link in postman: https://anounce-it.herokuapp.com/api/v1/announcement/:id

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [170785988](https://www.pivotaltracker.com/story/show/170785988)

#### Screenshots (if appropriate)
![delete](https://user-images.githubusercontent.com/37122177/72670330-f9b81780-3a44-11ea-9ae9-a95f6d653af7.PNG)
![not-found](https://user-images.githubusercontent.com/37122177/72670331-fa50ae00-3a44-11ea-8d6e-535b7f9f9969.PNG)
![unauthorized](https://user-images.githubusercontent.com/37122177/72670332-fae94480-3a44-11ea-8556-9a72a1156f67.PNG)
