### PR TITLE
#170993720 View announcement by status

### DIFF
--- a/server/Controllers/announcementController.js
+++ b/server/Controllers/announcementController.js
@@ -25,14 +25,14 @@ class AnnouncementController {
     return response.successResponse(res, 200, 'All your announcements', announcements);
   }
 
-  static findByStatus(req, res) {
+  static async findByStatus(req, res) {
     const theSatus = req.query.status;
-    const owner = req.user.firstname;
+    const owner = req.user.id;
     const isValidStatus = validStatus(theSatus);
     if (!isValidStatus) {
       return response.failureResponse(res, 400, 'Invalid Status');
     }
-    const announcements = query.findByStatus(theSatus, owner);
+    const announcements = await query.findByStatus(theSatus, owner);
     if (!announcements.length > 0) {
       return response.failureResponse(res, 404, 'Announcement not found');
     }

--- a/server/Helpers/announcementQuery.js
+++ b/server/Helpers/announcementQuery.js
@@ -46,8 +46,9 @@ class AnnouncementQuery {
     return rows;
   }
 
-  static findByStatus(status, owner) {
-    const announcements = Announcement.filter(a => a.owner === owner);
+  static async findByStatus(status, owner) {
+    const { rows } = await db.query('SELECT * FROM announcements WHERE "userId"=$1', [owner]);
+    const announcements = rows;
     return announcements.filter(a => a.status === status);
   }
 

--- a/server/Routes/announcementRoutes.js
+++ b/server/Routes/announcementRoutes.js
@@ -13,7 +13,7 @@ const router = express.Router();
 router.post('/api/v2/announcement', authentication, validation, duplication, announcementController.create);
 router.patch('/api/v2/announcement/:id', authentication, checkId, notFound, authorization, validation, announcementController.update);
 router.get('/api/v2/announcement', authentication, announcementController.all);
-router.get('/api/v1/announcements', authentication, announcementController.findByStatus);
+router.get('/api/v2/announcements', authentication, announcementController.findByStatus);
 router.get('/api/v1/announcement/:id', authentication, checkId, notFound, authorization, announcementController.getAnnouncement);
 router.delete('/api/v1/announcement/:id', authentication, checkId, notFound, checkAdmin, announcementController.delete);
 router.patch('/api/v1/announcements/:id', authentication, checkId, notFound, checkAdmin, announcementController.changeStatus);

--- a/server/Tests/announcementsTest.test.js
+++ b/server/Tests/announcementsTest.test.js
@@ -145,4 +145,36 @@ describe('Announcement tests', () => {
         done();
       });
   });
+  it('should get all announcements with a specific status', (done) => {
+    chai.request(server)
+      .get(`/api/v2/announcements?status=${announcementStatus}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(200);
+        expect(res.body.message).to.equal('Announcements by status');
+        done();
+      });
+  });
+
+  it('should not get all announcements if no announcement is found with that status', (done) => {
+    chai.request(server)
+      .get('/api/v2/announcements?status=active')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(404);
+        expect(res.body.error).to.equal('Announcement not found');
+        done();
+      });
+  });
+
+  it('should not get all announcements with invalid status', (done) => {
+    chai.request(server)
+      .get('/api/v2/announcements?status=abc')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(400);
+        expect(res.body.error).to.equal('Invalid Status');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

- It allows the user to view all announcement by a specific status

#### Description of Task to be completed?

- User can get all announcements by a specific status from the Postgres database

#### How should this be manually tested?

- Use this link in postman: https://anounce-it.herokuapp.com/api/v2/announcements

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [170993720](https://www.pivotaltracker.com/story/show/170993720)

#### Screenshots (if appropriate)
![by_status](https://user-images.githubusercontent.com/37122177/73442854-3990d000-435e-11ea-81be-36bca5f8d712.PNG)
