### PR TITLE
#170994024 View a specific announcement from the database

### DIFF
--- a/server/Controllers/announcementController.js
+++ b/server/Controllers/announcementController.js
@@ -39,9 +39,9 @@ class AnnouncementController {
     return response.successResponse(res, 200, 'Announcements by status', announcements);
   }
 
-  static getAnnouncement(req, res) {
+  static async getAnnouncement(req, res) {
     const id = parseInt(req.params.id);
-    const announcement = query.findById(id);
+    const announcement = await query.findById(id);
     return response.successResponse(res, 200, 'Annoucement', announcement);
   }
 

--- a/server/Routes/announcementRoutes.js
+++ b/server/Routes/announcementRoutes.js
@@ -14,7 +14,7 @@ router.post('/api/v2/announcement', authentication, validation, duplication, ann
 router.patch('/api/v2/announcement/:id', authentication, checkId, notFound, authorization, validation, announcementController.update);
 router.get('/api/v2/announcement', authentication, announcementController.all);
 router.get('/api/v2/announcements', authentication, announcementController.findByStatus);
-router.get('/api/v1/announcement/:id', authentication, checkId, notFound, authorization, announcementController.getAnnouncement);
+router.get('/api/v2/announcement/:id', authentication, checkId, notFound, authorization, announcementController.getAnnouncement);
 router.delete('/api/v1/announcement/:id', authentication, checkId, notFound, checkAdmin, announcementController.delete);
 router.patch('/api/v1/announcements/:id', authentication, checkId, notFound, checkAdmin, announcementController.changeStatus);
 router.get('/api/v1/announcemente/', authentication, checkAdmin, announcementController.allAnnouncements);

--- a/server/Tests/announcementsTest.test.js
+++ b/server/Tests/announcementsTest.test.js
@@ -177,4 +177,36 @@ describe('Announcement tests', () => {
         done();
       });
   });
+  it('should get an announcement', (done) => {
+    chai.request(server)
+      .get(`/api/v2/announcement/${announcementID}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(200);
+        expect(res.body.message).to.equal('Annoucement');
+        done();
+      });
+  });
+
+  it('should work provided invalid routes', (done) => {
+    chai.request(server)
+      .put(`/api/v0/announcement/${announcementID}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(400);
+        expect(res.body.error).to.equal('Incorrect Route');
+        done();
+      });
+  });
+
+  it('should not get an announcement provided invalid id', (done) => {
+    chai.request(server)
+      .get('/api/v2/announcement/id')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(400);
+        expect(res.body.error).to.equal('Please provide a valid id');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

- It allows the user to view a specific announcement

#### Description of Task to be completed?

- The user can view a specific announcement from the Postgres database

#### How should this be manually tested?

- Use this link in postman: https://anounce-it.herokuapp.com/api/v2/announcement/:id

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [170994024](https://www.pivotaltracker.com/story/show/170994024)

#### Screenshots (if appropriate)
![announcement](https://user-images.githubusercontent.com/37122177/73444546-70b4b080-4361-11ea-8da8-e18354ba8609.PNG)