### PR TITLE
#170994433 Change status of an announcement in the database

### DIFF
--- a/server/Controllers/announcementController.js
+++ b/server/Controllers/announcementController.js
@@ -51,14 +51,14 @@ class AnnouncementController {
     return response.deleteResponse(res, 200, 'Announcement Deleted successfully');
   }
 
-  static changeStatus(req, res) {
+  static async changeStatus(req, res) {
     const id = parseInt(req.params.id);
     const theStatus = req.query.status;
     const isValidStatus = validStatus(theStatus);
     if (!isValidStatus) {
       return response.failureResponse(res, 400, 'Invalid Status');
     }
-    const announcement = query.changeStatus(id, theStatus);
+    const announcement = await query.changeStatus(id, theStatus);
     return response.successResponse(res, 200, 'Status changed successfully', announcement);
   }
 

--- a/server/Helpers/announcementQuery.js
+++ b/server/Helpers/announcementQuery.js
@@ -24,10 +24,14 @@ class AnnouncementQuery {
     return rows[0];
   }
 
-  static changeStatus(id, status) {
-    const announcementIndex = Announcement.findIndex(a => a.id === id);
-    Announcement[announcementIndex].status = status;
-    return Announcement[announcementIndex];
+  static async changeStatus(id, status) {
+    const { rows } = await db.query('SELECT * FROM announcements WHERE id=$1', [id]);
+    const announcement = rows[0];
+    const updateQuery = 'UPDATE announcements SET text=$1, status=$2, owner=$3, "endDate"=$4, "userId"=$5 WHERE id=$6 RETURNING id, text,status,owner,"endDate","createdDate"';
+    const values = [announcement.text, status, announcement.owner, announcement.endDate, announcement.userId, id];
+    const change = await db.query(updateQuery, values);
+    const result = change.rows;
+    return result;
   }
 
   static async updateAnnouncement(id, data) {

--- a/server/Middlewares/checkAdmin.js
+++ b/server/Middlewares/checkAdmin.js
@@ -2,7 +2,7 @@ import response from '../Helpers/response';
 
 const checkAdmin = (req, res, next) => {
   const currentUser = req.user;
-  if (!currentUser.is_admin) {
+  if (!currentUser.isAdmin) {
     return response.failureResponse(res, 403, 'Forbidden operation');
   }
   return next();

--- a/server/Routes/announcementRoutes.js
+++ b/server/Routes/announcementRoutes.js
@@ -15,7 +15,7 @@ router.patch('/api/v2/announcement/:id', authentication, checkId, notFound, auth
 router.get('/api/v2/announcement', authentication, announcementController.all);
 router.get('/api/v2/announcements', authentication, announcementController.findByStatus);
 router.get('/api/v2/announcement/:id', authentication, checkId, notFound, authorization, announcementController.getAnnouncement);
-router.delete('/api/v1/announcement/:id', authentication, checkId, notFound, checkAdmin, announcementController.delete);
-router.patch('/api/v1/announcements/:id', authentication, checkId, notFound, checkAdmin, announcementController.changeStatus);
-router.get('/api/v1/announcemente/', authentication, checkAdmin, announcementController.allAnnouncements);
+router.delete('/api/v2/announcement/:id', authentication, checkId, notFound, checkAdmin, announcementController.delete);
+router.patch('/api/v2/announcements/:id', authentication, checkId, notFound, checkAdmin, announcementController.changeStatus);
+router.get('/api/v2/announcemente/', authentication, checkAdmin, announcementController.allAnnouncements);
 export default router;

--- a/server/Tests/announcementsTest.test.js
+++ b/server/Tests/announcementsTest.test.js
@@ -209,4 +209,25 @@ describe('Announcement tests', () => {
         done();
       });
   });
+  it('should change the status an announcement', (done) => {
+    chai.request(server)
+      .patch(`/api/v2/announcements/${announcementID}?status=active`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(200);
+        expect(res.body.message).to.equal('Status changed successfully');
+        done();
+      });
+  });
+
+  it('should not change the status an announcement provided invalid status', (done) => {
+    chai.request(server)
+      .patch(`/api/v2/announcements/${announcementID}?status=notAStatus`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(400);
+        expect(res.body.error).to.equal('Invalid Status');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

- It allows the admin to change the status of an announcement.

#### Description of Task to be completed?

- The admin can change the status of an announcement in the database

#### How should this be manually tested?

- Use this link postman: https://anounce-it.herokuapp.com/api/v2/announcements/:id

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [170994433](https://www.pivotaltracker.com/story/show/170994433)

#### Screenshots (if appropriate)
![change](https://user-images.githubusercontent.com/37122177/73446058-bfb01500-4364-11ea-8880-a4225048808b.PNG)
![unauthorized](https://user-images.githubusercontent.com/37122177/73446061-bfb01500-4364-11ea-8f3f-270d75ce1cd8.PNG)