### PR TITLE
#170995081 View all announcements from database

### DIFF
--- a/server/Controllers/announcementController.js
+++ b/server/Controllers/announcementController.js
@@ -62,8 +62,9 @@ class AnnouncementController {
     return response.successResponse(res, 200, 'Status changed successfully', announcement);
   }
 
-  static allAnnouncements(req, res) {
-    return response.successResponse(res, 200, 'All announcements', Annoucement);
+  static async allAnnouncements(req, res) {
+    const announcements = await query.allTheAnnoucements();
+    return response.successResponse(res, 200, 'All announcements', announcements);
   }
 }
 export default AnnouncementController;

--- a/server/Helpers/announcementQuery.js
+++ b/server/Helpers/announcementQuery.js
@@ -71,5 +71,10 @@ class AnnouncementQuery {
     const { rows } = await db.query('SELECT * FROM announcements WHERE text=$1', [text]);
     return rows[0];
   }
+
+  static async allTheAnnoucements() {
+    const { rows } = await db.query('SELECT * FROM announcements');
+    return rows;
+  }
 }
 export default AnnouncementQuery;

--- a/server/Tests/announcementsTest.test.js
+++ b/server/Tests/announcementsTest.test.js
@@ -230,4 +230,14 @@ describe('Announcement tests', () => {
         done();
       });
   });
+  it('should view all announcements', (done) => {
+    chai.request(server)
+      .get('/api/v2/announcemente')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((error, res) => {
+        res.body.status.should.be.equal(200);
+        expect(res.body.message).to.equal('All announcements');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

- It allows the admin to view all announcements

#### Description of Task to be completed?

- The admin can view all announcement from the database

#### How should this be manually tested?

- Use this link in postman: https://anounce-it.herokuapp.com/api/v2/announcemente/

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [170995081](https://www.pivotaltracker.com/story/show/170995081)

#### Screenshots (if appropriate)
![all](https://user-images.githubusercontent.com/37122177/73447897-5a5e2300-4368-11ea-824b-2c76e8738661.PNG)
![unauthorized](https://user-images.githubusercontent.com/37122177/73447907-60ec9a80-4368-11ea-80b4-55db2258e021.PNG)
